### PR TITLE
Minor fixes for the builder image

### DIFF
--- a/okd-golang-builder.Dockerfile
+++ b/okd-golang-builder.Dockerfile
@@ -11,7 +11,7 @@ ENV container=oci \
     GOMAXPROCS=8
 
 RUN mkdir -p /go/src/ && \
-    yum install -y --enablerepo=* --disablerepo=nfv-source --setopt=skip_missing_names_on_install=False \
+    yum install -y --enablerepo=* --disablerepo=nfv-source --setopt=skip_missing_names_on_install=False --setopt=skip_if_unavailable=True \
         bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
         go-toolset openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
     yum clean all && \

--- a/okd-golang-builder.Dockerfile
+++ b/okd-golang-builder.Dockerfile
@@ -11,6 +11,7 @@ ENV container=oci \
     GOMAXPROCS=8
 
 RUN mkdir -p /go/src/ && \
+    yum upgrade --refresh -y && \
     yum install -y --enablerepo=* --disablerepo=nfv-source --setopt=skip_missing_names_on_install=False --setopt=skip_if_unavailable=True \
         bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
         go-toolset openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \


### PR DESCRIPTION
This PR adds some minor fixes for the builder image:
- packages are updated before installing deps (as of now, two packages were upgraded and they were causing issues to the linker when building oc for aarch64)
- given the enable-repo=* parameter, I set the command to skip unavailable repos. It can happen that some repos are not available for some architectures, e.g., `rt` on aarch64. The (404) error is now ignored and the repo is not enabled.

cc @LorbusChris 