### PR TITLE
Install go-toolset 1.19 as now available in the official repos

### DIFF
--- a/okd-builder.Dockerfile
+++ b/okd-builder.Dockerfile
@@ -22,11 +22,8 @@ RUN set -x; mkdir -p /go/src/ \
     && yum upgrade --refresh -y \
     && yum install -y \
         bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
-        gcc-toolset-12 nodejs npm openssl openssl-devel \
+        gcc-toolset-12 go-toolset nodejs npm openssl openssl-devel \
         systemd-devel gpgme-devel libassuan-devel \
-        https://kojihub.stream.centos.org/kojifiles/packages/golang/1.19.1/2.el9/$(uname -m)/golang-1.19.1-2.el9.$(uname -m).rpm \
-        https://kojihub.stream.centos.org/kojifiles/packages/golang/1.19.1/2.el9/$(uname -m)/golang-bin-1.19.1-2.el9.$(uname -m).rpm \
-        https://kojihub.stream.centos.org/kojifiles/packages/golang/1.19.1/2.el9/noarch/golang-src-1.19.1-2.el9.noarch.rpm \
     && yum clean all \
     # goversioninfo is not shipped as RPM in Stream9, so install it with go instead
     && GOFLAGS='' go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest


### PR DESCRIPTION
We recently installed the go 1.19 related packages from koji as they weren't available in the official repositories. Since they're now available, we can remove the pin to the kojihub rpms